### PR TITLE
Mark extension as reproducible

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,6 +18,7 @@ module(
     version = "0.0.0",
 )
 
+bazel_dep(name = "bazel_features", version = "1.20.0")
 bazel_dep(name = "abseil-cpp", version = "20240116.1", repo_name = "com_google_absl")
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
 bazel_dep(name = "platforms", version = "0.0.8")

--- a/fuzzing/private/extensions.bzl
+++ b/fuzzing/private/extensions.bzl
@@ -14,9 +14,15 @@
 
 """Internal dependencies that are not Bazel modules."""
 
+load("@bazel_features//:features.bzl", "bazel_features")
 load("//fuzzing:repositories.bzl", "rules_fuzzing_dependencies")
 
-def _non_module_dependencies(_):
+def _non_module_dependencies(mctx):
     rules_fuzzing_dependencies()
+
+    if bazel_features.external_deps.extension_metadata_has_reproducible:
+        return mctx.extension_metadata(reproducible = True)
+
+    return None
 
 non_module_dependencies = module_extension(_non_module_dependencies)


### PR DESCRIPTION
This removes an unnecessary entry from the lockfiles of rules_fuzzing users.