### PR TITLE
Propagate tags and target_compatible_with to generated bazel targets

### DIFF
--- a/docs/cc-fuzzing-rules.md
+++ b/docs/cc-fuzzing-rules.md
@@ -58,7 +58,8 @@ Provider for storing the language-independent part of the specification of a fuz
 <pre>
 load("@rules_fuzzing//fuzzing:cc_defs.bzl", "cc_fuzz_test")
 
-cc_fuzz_test(<a href="#cc_fuzz_test-name">name</a>, <a href="#cc_fuzz_test-corpus">corpus</a>, <a href="#cc_fuzz_test-dicts">dicts</a>, <a href="#cc_fuzz_test-engine">engine</a>, <a href="#cc_fuzz_test-size">size</a>, <a href="#cc_fuzz_test-tags">tags</a>, <a href="#cc_fuzz_test-timeout">timeout</a>, <a href="#cc_fuzz_test-binary_kwargs">**binary_kwargs</a>)
+cc_fuzz_test(<a href="#cc_fuzz_test-name">name</a>, <a href="#cc_fuzz_test-corpus">corpus</a>, <a href="#cc_fuzz_test-dicts">dicts</a>, <a href="#cc_fuzz_test-engine">engine</a>, <a href="#cc_fuzz_test-size">size</a>, <a href="#cc_fuzz_test-tags">tags</a>, <a href="#cc_fuzz_test-target_compatible_with">target_compatible_with</a>, <a href="#cc_fuzz_test-timeout">timeout</a>,
+             <a href="#cc_fuzz_test-binary_kwargs">**binary_kwargs</a>)
 </pre>
 
 Defines a C++ fuzz test and a few associated tools and metadata.
@@ -92,6 +93,7 @@ most relevant ones are:
 | <a id="cc_fuzz_test-engine"></a>engine |  A label pointing to the fuzzing engine to use.   |  `Label("@rules_fuzzing//fuzzing:cc_engine")` |
 | <a id="cc_fuzz_test-size"></a>size |  The size of the regression test. This does *not* affect fuzzing itself. Takes the [common size values](https://bazel.build/reference/be/common-definitions#test.size).   |  `None` |
 | <a id="cc_fuzz_test-tags"></a>tags |  Tags set on the generated targets.   |  `None` |
+| <a id="cc_fuzz_test-target_compatible_with"></a>target_compatible_with |  Platform constraints set on the generated targets.   |  `None` |
 | <a id="cc_fuzz_test-timeout"></a>timeout |  The timeout for the regression test. This does *not* affect fuzzing itself. Takes the [common timeout values](https://docs.bazel.build/versions/main/be/common-definitions.html#test.timeout).   |  `None` |
 | <a id="cc_fuzz_test-binary_kwargs"></a>binary_kwargs |  Keyword arguments directly forwarded to the fuzz test binary rule.   |  none |
 
@@ -104,7 +106,8 @@ most relevant ones are:
 load("@rules_fuzzing//fuzzing:cc_defs.bzl", "fuzzing_decoration")
 
 fuzzing_decoration(<a href="#fuzzing_decoration-name">name</a>, <a href="#fuzzing_decoration-raw_binary">raw_binary</a>, <a href="#fuzzing_decoration-engine">engine</a>, <a href="#fuzzing_decoration-corpus">corpus</a>, <a href="#fuzzing_decoration-dicts">dicts</a>, <a href="#fuzzing_decoration-instrument_binary">instrument_binary</a>,
-                   <a href="#fuzzing_decoration-define_regression_test">define_regression_test</a>, <a href="#fuzzing_decoration-tags">tags</a>, <a href="#fuzzing_decoration-test_size">test_size</a>, <a href="#fuzzing_decoration-test_tags">test_tags</a>, <a href="#fuzzing_decoration-test_timeout">test_timeout</a>)
+                   <a href="#fuzzing_decoration-define_regression_test">define_regression_test</a>, <a href="#fuzzing_decoration-tags">tags</a>, <a href="#fuzzing_decoration-target_compatible_with">target_compatible_with</a>, <a href="#fuzzing_decoration-test_size">test_size</a>, <a href="#fuzzing_decoration-test_tags">test_tags</a>,
+                   <a href="#fuzzing_decoration-test_timeout">test_timeout</a>)
 </pre>
 
 Generates the standard targets associated to a fuzz test.
@@ -127,6 +130,7 @@ documentation for the set of targets generated.
 | <a id="fuzzing_decoration-instrument_binary"></a>instrument_binary |  **(Experimental, may be removed in the future.)**<br><br>By default, the generated targets depend on `raw_binary` through a Bazel configuration using flags from the `@rules_fuzzing//fuzzing` package to determine the fuzzing build mode, engine, and sanitizer instrumentation.<br><br>When this argument is false, the targets assume that `raw_binary` is already built in the proper configuration and will not apply the transition.<br><br>Most users should not need to change this argument. If you think the default instrumentation mode does not work for your use case, please file a Github issue to discuss.   |  `True` |
 | <a id="fuzzing_decoration-define_regression_test"></a>define_regression_test |  If true, generate a regression test rule.   |  `True` |
 | <a id="fuzzing_decoration-tags"></a>tags |  Additional tags set on non-test targets.   |  `None` |
+| <a id="fuzzing_decoration-target_compatible_with"></a>target_compatible_with |  Platform constraints set on the generated targets.   |  `None` |
 | <a id="fuzzing_decoration-test_size"></a>test_size |  The size of the fuzzing regression test.   |  `None` |
 | <a id="fuzzing_decoration-test_tags"></a>test_tags |  Tags set on the fuzzing regression test.   |  `None` |
 | <a id="fuzzing_decoration-test_timeout"></a>test_timeout |  The timeout for the fuzzing regression test.   |  `None` |

--- a/docs/cc-fuzzing-rules.md
+++ b/docs/cc-fuzzing-rules.md
@@ -91,7 +91,7 @@ most relevant ones are:
 | <a id="cc_fuzz_test-dicts"></a>dicts |  A list containing dictionaries.   |  `None` |
 | <a id="cc_fuzz_test-engine"></a>engine |  A label pointing to the fuzzing engine to use.   |  `Label("@rules_fuzzing//fuzzing:cc_engine")` |
 | <a id="cc_fuzz_test-size"></a>size |  The size of the regression test. This does *not* affect fuzzing itself. Takes the [common size values](https://bazel.build/reference/be/common-definitions#test.size).   |  `None` |
-| <a id="cc_fuzz_test-tags"></a>tags |  Tags set on the regression test.   |  `None` |
+| <a id="cc_fuzz_test-tags"></a>tags |  Tags set on the generated targets.   |  `None` |
 | <a id="cc_fuzz_test-timeout"></a>timeout |  The timeout for the regression test. This does *not* affect fuzzing itself. Takes the [common timeout values](https://docs.bazel.build/versions/main/be/common-definitions.html#test.timeout).   |  `None` |
 | <a id="cc_fuzz_test-binary_kwargs"></a>binary_kwargs |  Keyword arguments directly forwarded to the fuzz test binary rule.   |  none |
 
@@ -104,7 +104,7 @@ most relevant ones are:
 load("@rules_fuzzing//fuzzing:cc_defs.bzl", "fuzzing_decoration")
 
 fuzzing_decoration(<a href="#fuzzing_decoration-name">name</a>, <a href="#fuzzing_decoration-raw_binary">raw_binary</a>, <a href="#fuzzing_decoration-engine">engine</a>, <a href="#fuzzing_decoration-corpus">corpus</a>, <a href="#fuzzing_decoration-dicts">dicts</a>, <a href="#fuzzing_decoration-instrument_binary">instrument_binary</a>,
-                   <a href="#fuzzing_decoration-define_regression_test">define_regression_test</a>, <a href="#fuzzing_decoration-test_size">test_size</a>, <a href="#fuzzing_decoration-test_tags">test_tags</a>, <a href="#fuzzing_decoration-test_timeout">test_timeout</a>)
+                   <a href="#fuzzing_decoration-define_regression_test">define_regression_test</a>, <a href="#fuzzing_decoration-tags">tags</a>, <a href="#fuzzing_decoration-test_size">test_size</a>, <a href="#fuzzing_decoration-test_tags">test_tags</a>, <a href="#fuzzing_decoration-test_timeout">test_timeout</a>)
 </pre>
 
 Generates the standard targets associated to a fuzz test.
@@ -126,6 +126,7 @@ documentation for the set of targets generated.
 | <a id="fuzzing_decoration-dicts"></a>dicts |  A list of fuzzing dictionary files.   |  `None` |
 | <a id="fuzzing_decoration-instrument_binary"></a>instrument_binary |  **(Experimental, may be removed in the future.)**<br><br>By default, the generated targets depend on `raw_binary` through a Bazel configuration using flags from the `@rules_fuzzing//fuzzing` package to determine the fuzzing build mode, engine, and sanitizer instrumentation.<br><br>When this argument is false, the targets assume that `raw_binary` is already built in the proper configuration and will not apply the transition.<br><br>Most users should not need to change this argument. If you think the default instrumentation mode does not work for your use case, please file a Github issue to discuss.   |  `True` |
 | <a id="fuzzing_decoration-define_regression_test"></a>define_regression_test |  If true, generate a regression test rule.   |  `True` |
+| <a id="fuzzing_decoration-tags"></a>tags |  Additional tags set on non-test targets.   |  `None` |
 | <a id="fuzzing_decoration-test_size"></a>test_size |  The size of the fuzzing regression test.   |  `None` |
 | <a id="fuzzing_decoration-test_tags"></a>test_tags |  Tags set on the fuzzing regression test.   |  `None` |
 | <a id="fuzzing_decoration-test_timeout"></a>test_timeout |  The timeout for the fuzzing regression test.   |  `None` |

--- a/docs/java-fuzzing-rules.md
+++ b/docs/java-fuzzing-rules.md
@@ -59,7 +59,8 @@ Provider for storing the language-independent part of the specification of a fuz
 load("@rules_fuzzing//fuzzing:java_defs.bzl", "fuzzing_decoration")
 
 fuzzing_decoration(<a href="#fuzzing_decoration-name">name</a>, <a href="#fuzzing_decoration-raw_binary">raw_binary</a>, <a href="#fuzzing_decoration-engine">engine</a>, <a href="#fuzzing_decoration-corpus">corpus</a>, <a href="#fuzzing_decoration-dicts">dicts</a>, <a href="#fuzzing_decoration-instrument_binary">instrument_binary</a>,
-                   <a href="#fuzzing_decoration-define_regression_test">define_regression_test</a>, <a href="#fuzzing_decoration-tags">tags</a>, <a href="#fuzzing_decoration-test_size">test_size</a>, <a href="#fuzzing_decoration-test_tags">test_tags</a>, <a href="#fuzzing_decoration-test_timeout">test_timeout</a>)
+                   <a href="#fuzzing_decoration-define_regression_test">define_regression_test</a>, <a href="#fuzzing_decoration-tags">tags</a>, <a href="#fuzzing_decoration-target_compatible_with">target_compatible_with</a>, <a href="#fuzzing_decoration-test_size">test_size</a>, <a href="#fuzzing_decoration-test_tags">test_tags</a>,
+                   <a href="#fuzzing_decoration-test_timeout">test_timeout</a>)
 </pre>
 
 Generates the standard targets associated to a fuzz test.
@@ -82,6 +83,7 @@ documentation for the set of targets generated.
 | <a id="fuzzing_decoration-instrument_binary"></a>instrument_binary |  **(Experimental, may be removed in the future.)**<br><br>By default, the generated targets depend on `raw_binary` through a Bazel configuration using flags from the `@rules_fuzzing//fuzzing` package to determine the fuzzing build mode, engine, and sanitizer instrumentation.<br><br>When this argument is false, the targets assume that `raw_binary` is already built in the proper configuration and will not apply the transition.<br><br>Most users should not need to change this argument. If you think the default instrumentation mode does not work for your use case, please file a Github issue to discuss.   |  `True` |
 | <a id="fuzzing_decoration-define_regression_test"></a>define_regression_test |  If true, generate a regression test rule.   |  `True` |
 | <a id="fuzzing_decoration-tags"></a>tags |  Additional tags set on non-test targets.   |  `None` |
+| <a id="fuzzing_decoration-target_compatible_with"></a>target_compatible_with |  Platform constraints set on the generated targets.   |  `None` |
 | <a id="fuzzing_decoration-test_size"></a>test_size |  The size of the fuzzing regression test.   |  `None` |
 | <a id="fuzzing_decoration-test_tags"></a>test_tags |  Tags set on the fuzzing regression test.   |  `None` |
 | <a id="fuzzing_decoration-test_timeout"></a>test_timeout |  The timeout for the fuzzing regression test.   |  `None` |
@@ -94,8 +96,8 @@ documentation for the set of targets generated.
 <pre>
 load("@rules_fuzzing//fuzzing:java_defs.bzl", "java_fuzz_test")
 
-java_fuzz_test(<a href="#java_fuzz_test-name">name</a>, <a href="#java_fuzz_test-srcs">srcs</a>, <a href="#java_fuzz_test-target_class">target_class</a>, <a href="#java_fuzz_test-corpus">corpus</a>, <a href="#java_fuzz_test-dicts">dicts</a>, <a href="#java_fuzz_test-engine">engine</a>, <a href="#java_fuzz_test-size">size</a>, <a href="#java_fuzz_test-tags">tags</a>, <a href="#java_fuzz_test-timeout">timeout</a>,
-               <a href="#java_fuzz_test-binary_kwargs">**binary_kwargs</a>)
+java_fuzz_test(<a href="#java_fuzz_test-name">name</a>, <a href="#java_fuzz_test-srcs">srcs</a>, <a href="#java_fuzz_test-target_class">target_class</a>, <a href="#java_fuzz_test-corpus">corpus</a>, <a href="#java_fuzz_test-dicts">dicts</a>, <a href="#java_fuzz_test-engine">engine</a>, <a href="#java_fuzz_test-size">size</a>, <a href="#java_fuzz_test-tags">tags</a>, <a href="#java_fuzz_test-target_compatible_with">target_compatible_with</a>,
+               <a href="#java_fuzz_test-timeout">timeout</a>, <a href="#java_fuzz_test-binary_kwargs">**binary_kwargs</a>)
 </pre>
 
 Defines a Java fuzz test and a few associated tools and metadata.
@@ -131,6 +133,7 @@ most relevant ones are:
 | <a id="java_fuzz_test-engine"></a>engine |  A label pointing to the fuzzing engine to use.   |  `Label("@rules_fuzzing//fuzzing:java_engine")` |
 | <a id="java_fuzz_test-size"></a>size |  The size of the regression test. This does *not* affect fuzzing itself. Takes the [common size values](https://bazel.build/reference/be/common-definitions#test.size).   |  `None` |
 | <a id="java_fuzz_test-tags"></a>tags |  Tags set on the generated targets.   |  `None` |
+| <a id="java_fuzz_test-target_compatible_with"></a>target_compatible_with |  Platform constraints set on the generated targets.   |  `None` |
 | <a id="java_fuzz_test-timeout"></a>timeout |  The timeout for the regression test. This does *not* affect fuzzing itself. Takes the [common timeout values](https://docs.bazel.build/versions/main/be/common-definitions.html#test.timeout).   |  `None` |
 | <a id="java_fuzz_test-binary_kwargs"></a>binary_kwargs |  Keyword arguments directly forwarded to the fuzz test binary rule.   |  none |
 

--- a/docs/java-fuzzing-rules.md
+++ b/docs/java-fuzzing-rules.md
@@ -59,7 +59,7 @@ Provider for storing the language-independent part of the specification of a fuz
 load("@rules_fuzzing//fuzzing:java_defs.bzl", "fuzzing_decoration")
 
 fuzzing_decoration(<a href="#fuzzing_decoration-name">name</a>, <a href="#fuzzing_decoration-raw_binary">raw_binary</a>, <a href="#fuzzing_decoration-engine">engine</a>, <a href="#fuzzing_decoration-corpus">corpus</a>, <a href="#fuzzing_decoration-dicts">dicts</a>, <a href="#fuzzing_decoration-instrument_binary">instrument_binary</a>,
-                   <a href="#fuzzing_decoration-define_regression_test">define_regression_test</a>, <a href="#fuzzing_decoration-test_size">test_size</a>, <a href="#fuzzing_decoration-test_tags">test_tags</a>, <a href="#fuzzing_decoration-test_timeout">test_timeout</a>)
+                   <a href="#fuzzing_decoration-define_regression_test">define_regression_test</a>, <a href="#fuzzing_decoration-tags">tags</a>, <a href="#fuzzing_decoration-test_size">test_size</a>, <a href="#fuzzing_decoration-test_tags">test_tags</a>, <a href="#fuzzing_decoration-test_timeout">test_timeout</a>)
 </pre>
 
 Generates the standard targets associated to a fuzz test.
@@ -81,6 +81,7 @@ documentation for the set of targets generated.
 | <a id="fuzzing_decoration-dicts"></a>dicts |  A list of fuzzing dictionary files.   |  `None` |
 | <a id="fuzzing_decoration-instrument_binary"></a>instrument_binary |  **(Experimental, may be removed in the future.)**<br><br>By default, the generated targets depend on `raw_binary` through a Bazel configuration using flags from the `@rules_fuzzing//fuzzing` package to determine the fuzzing build mode, engine, and sanitizer instrumentation.<br><br>When this argument is false, the targets assume that `raw_binary` is already built in the proper configuration and will not apply the transition.<br><br>Most users should not need to change this argument. If you think the default instrumentation mode does not work for your use case, please file a Github issue to discuss.   |  `True` |
 | <a id="fuzzing_decoration-define_regression_test"></a>define_regression_test |  If true, generate a regression test rule.   |  `True` |
+| <a id="fuzzing_decoration-tags"></a>tags |  Additional tags set on non-test targets.   |  `None` |
 | <a id="fuzzing_decoration-test_size"></a>test_size |  The size of the fuzzing regression test.   |  `None` |
 | <a id="fuzzing_decoration-test_tags"></a>test_tags |  Tags set on the fuzzing regression test.   |  `None` |
 | <a id="fuzzing_decoration-test_timeout"></a>test_timeout |  The timeout for the fuzzing regression test.   |  `None` |
@@ -129,7 +130,7 @@ most relevant ones are:
 | <a id="java_fuzz_test-dicts"></a>dicts |  A list containing dictionaries.   |  `None` |
 | <a id="java_fuzz_test-engine"></a>engine |  A label pointing to the fuzzing engine to use.   |  `Label("@rules_fuzzing//fuzzing:java_engine")` |
 | <a id="java_fuzz_test-size"></a>size |  The size of the regression test. This does *not* affect fuzzing itself. Takes the [common size values](https://bazel.build/reference/be/common-definitions#test.size).   |  `None` |
-| <a id="java_fuzz_test-tags"></a>tags |  Tags set on the regression test.   |  `None` |
+| <a id="java_fuzz_test-tags"></a>tags |  Tags set on the generated targets.   |  `None` |
 | <a id="java_fuzz_test-timeout"></a>timeout |  The timeout for the regression test. This does *not* affect fuzzing itself. Takes the [common timeout values](https://docs.bazel.build/versions/main/be/common-definitions.html#test.timeout).   |  `None` |
 | <a id="java_fuzz_test-binary_kwargs"></a>binary_kwargs |  Keyword arguments directly forwarded to the fuzz test binary rule.   |  none |
 

--- a/fuzzing/private/fuzz_test.bzl
+++ b/fuzzing/private/fuzz_test.bzl
@@ -32,6 +32,7 @@ def fuzzing_decoration(
         instrument_binary = True,
         define_regression_test = True,
         tags = None,
+        target_compatible_with = None,
         test_size = None,
         test_tags = None,
         test_timeout = None):
@@ -65,6 +66,7 @@ def fuzzing_decoration(
           file a Github issue to discuss.
         define_regression_test: If true, generate a regression test rule.
         tags: Additional tags set on non-test targets.
+        target_compatible_with: Platform constraints set on the generated targets.
         test_size: The size of the fuzzing regression test.
         test_tags: Tags set on the fuzzing regression test.
         test_timeout: The timeout for the fuzzing regression test.
@@ -91,6 +93,7 @@ def fuzzing_decoration(
             dictionary = dict_name if dicts else None,
             testonly = True,
             tags = tags,
+            target_compatible_with = target_compatible_with,
         )
     else:
         fuzzing_binary_uninstrumented(
@@ -101,6 +104,7 @@ def fuzzing_decoration(
             dictionary = dict_name if dicts else None,
             testonly = True,
             tags = tags,
+            target_compatible_with = target_compatible_with,
         )
 
     fuzzing_corpus(
@@ -108,6 +112,7 @@ def fuzzing_decoration(
         srcs = corpus,
         testonly = True,
         tags = tags,
+        target_compatible_with = target_compatible_with,
     )
 
     if dicts:
@@ -117,6 +122,7 @@ def fuzzing_decoration(
             output = name + ".dict",
             testonly = True,
             tags = tags,
+            target_compatible_with = target_compatible_with,
         )
 
     fuzzing_launcher(
@@ -124,6 +130,7 @@ def fuzzing_decoration(
         binary = instrum_binary_name,
         testonly = True,
         tags = tags,
+        target_compatible_with = target_compatible_with,
     )
 
     if define_regression_test:
@@ -133,6 +140,7 @@ def fuzzing_decoration(
             size = test_size,
             tags = test_tags,
             timeout = test_timeout,
+            target_compatible_with = target_compatible_with,
         )
 
     oss_fuzz_package(
@@ -141,6 +149,7 @@ def fuzzing_decoration(
         binary = instrum_binary_name,
         testonly = True,
         tags = tags,
+        target_compatible_with = target_compatible_with,
     )
 
 def cc_fuzz_test(
@@ -150,6 +159,7 @@ def cc_fuzz_test(
         engine = Label("//fuzzing:cc_engine"),
         size = None,
         tags = None,
+        target_compatible_with = None,
         timeout = None,
         **binary_kwargs):
     """Defines a C++ fuzz test and a few associated tools and metadata.
@@ -179,6 +189,7 @@ def cc_fuzz_test(
         size: The size of the regression test. This does *not* affect fuzzing
           itself. Takes the [common size values](https://bazel.build/reference/be/common-definitions#test.size).
         tags: Tags set on the generated targets.
+        target_compatible_with: Platform constraints set on the generated targets.
         timeout: The timeout for the regression test. This does *not* affect
           fuzzing itself. Takes the [common timeout values](https://docs.bazel.build/versions/main/be/common-definitions.html#test.timeout).
         **binary_kwargs: Keyword arguments directly forwarded to the fuzz test
@@ -200,6 +211,7 @@ def cc_fuzz_test(
     cc_binary(
         name = raw_binary_name,
         tags = (tags or []) + ["manual"],
+        target_compatible_with = target_compatible_with,
         **binary_kwargs
     )
 
@@ -210,6 +222,7 @@ def cc_fuzz_test(
         corpus = corpus,
         dicts = dicts,
         tags = tags,
+        target_compatible_with = target_compatible_with,
         test_size = size,
         test_tags = (tags or []) + [
             "fuzz-test",
@@ -235,6 +248,7 @@ def java_fuzz_test(
         engine = Label("//fuzzing:java_engine"),
         size = None,
         tags = None,
+        target_compatible_with = None,
         timeout = None,
         **binary_kwargs):
     """Defines a Java fuzz test and a few associated tools and metadata.
@@ -267,6 +281,7 @@ def java_fuzz_test(
         size: The size of the regression test. This does *not* affect fuzzing
           itself. Takes the [common size values](https://bazel.build/reference/be/common-definitions#test.size).
         tags: Tags set on the generated targets.
+        target_compatible_with: Platform constraints set on the generated targets.
         timeout: The timeout for the regression test. This does *not* affect
           fuzzing itself. Takes the [common timeout values](https://docs.bazel.build/versions/main/be/common-definitions.html#test.timeout).
         **binary_kwargs: Keyword arguments directly forwarded to the fuzz test
@@ -297,6 +312,7 @@ def java_fuzz_test(
         create_executable = False,
         deploy_manifest_lines = [target_class_manifest_line],
         tags = (tags or []) + ["manual"],
+        target_compatible_with = target_compatible_with,
     )
 
     # use += rather than append to allow users to pass in select() expressions for
@@ -327,6 +343,7 @@ def java_fuzz_test(
         srcs = srcs,
         main_class = "com.code_intelligence.jazzer.Jazzer",
         tags = (tags or []) + ["manual"],
+        target_compatible_with = target_compatible_with,
         **binary_kwargs
     )
 
@@ -351,6 +368,7 @@ def java_fuzz_test(
         }),
         target = raw_target_name,
         tags = (tags or []) + ["manual"],
+        target_compatible_with = target_compatible_with,
     )
 
     fuzzing_decoration(
@@ -360,6 +378,7 @@ def java_fuzz_test(
         corpus = corpus,
         dicts = dicts,
         tags = tags,
+        target_compatible_with = target_compatible_with,
         test_size = size,
         test_tags = (tags or []) + [
             "fuzz-test",


### PR DESCRIPTION
Forwards `tags` and `target_compatible_with` to the generated targets from `cc_fuzz_test`, `java_fuzz_test` and `fuzzing_decoration`.

Being able to modify tags and specify platform constraints is frequently needed in CI/CD integrations.