### PR TITLE
Fix source.template.json

### DIFF
--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,5 +1,5 @@
 {
   "integrity": "",
   "strip_prefix": "",
-  "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/rules_fuzzing-{VERSION}.tar.gz"
+  "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/rules_fuzzing-{TAG}.tar.gz"
 }


### PR DESCRIPTION
The release job creates an archive with the `v`-prefixed tag in the name, which caused the publish job to fail as it expected the name without the `v`.

https://github.com/bazel-contrib/rules_fuzzing/actions/runs/16354558276/job/46210158348#step:6:24