### PR TITLE
Fix source.template.json again

### DIFF
--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,5 +1,5 @@
 {
   "integrity": "",
-  "strip_prefix": "",
-  "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/rules_fuzzing-{TAG}.tar.gz"
+  "strip_prefix": "{REPO}-{TAG}",
+  "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/{REPO}-{TAG}.tar.gz"
 }


### PR DESCRIPTION
Add a strip_prefix to fix https://github.com/bazel-contrib/rules_fuzzing/actions/runs/16363893709/job/46237275734#step:6:25.